### PR TITLE
Fix up the broken renderer code

### DIFF
--- a/include/CUSTOM/GLmanager.hpp
+++ b/include/CUSTOM/GLmanager.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 

--- a/include/CUSTOM/renderer.hpp
+++ b/include/CUSTOM/renderer.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
@@ -12,16 +14,14 @@
 class Renderer
 {
 public:
-	struct
-	{
 		unsigned int VBO;
 		unsigned int VAO;
 
-		void createVBO(float vertices[])
+		void createVBO(float* vertices, GLsizeiptr size)
 		{
 			glGenBuffers(1, &VBO);
 			glBindBuffer(GL_ARRAY_BUFFER, VBO);
-			glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+			glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
 			std::cout << colour::bright_green << "INFO | Created VBO" << colour::reset << std::endl;
 		}
 		void createVAO()
@@ -31,10 +31,10 @@ public:
 			std::cout << colour::bright_green << "INFO | Created VAO" << colour::reset << std::endl;
 		}
 
-		void bindVBO(float vertices[])
+		void bindVBO(float* vertices, GLsizeiptr size)
 		{
 			glBindBuffer(GL_ARRAY_BUFFER, VBO);
-			glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+			glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
 			std::cout << colour::bright_green << "INFO | Bound VBO" << colour::reset << std::endl;
 		}
 		
@@ -42,7 +42,6 @@ public:
 		{
 
 		}
-	} vertices;
 
 private:
 

--- a/include/CUSTOM/textureManager.hpp
+++ b/include/CUSTOM/textureManager.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
@@ -17,10 +18,10 @@
 
 class Texture {
 public:
-	char* name;
-	char* path;
+	const char* name;
+	const char* path;
 	
-	Texture(char* name_, char* path_, bool pixelArt_, bool flipImage_)
+	Texture(const char* name_, const char* path_, bool pixelArt_, bool flipImage_)
 	{
 		name = name_;
 		path = path_;
@@ -125,16 +126,12 @@ class TextureManager {
 public:
 	void initTexture(const char* name_, const char* path_, bool pixelArt = true, bool flipImage = true)
 	{
-		char* name = (char*)name_;
-		char* path = (char*)path_;
-
-
-		Texture* tex = new Texture(name, path, pixelArt, flipImage);
-		textures[name] = tex;
+		Texture* tex = new Texture(name_, path_, pixelArt, flipImage);
+		textures[name_] = tex;
 
 		reloadPreviousTexture();
 	}
-	void useTexture(char* tex, bool setCurrent = true)
+	void useTexture(const char* tex, bool setCurrent = true)
 	{
 		if (tex == currentTexture) { return; }
 		previousTexture = currentTexture;
@@ -147,8 +144,8 @@ private:
 		if (previousTexture) { useTexture(previousTexture); }
 	}
 	std::map<const char*, Texture*> textures;
-	char* currentTexture = (char*)"None";
-	char* previousTexture = NULL;
+	const char* currentTexture = "None";
+	const char* previousTexture = NULL;
 };
 
 #endif // TextureManagerHeader

--- a/include/CUSTOM/tilemap.hpp
+++ b/include/CUSTOM/tilemap.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <GLAD/glad.h>
 #include <GLFW/glfw3.h>
 

--- a/include/CUSTOM/window.hpp
+++ b/include/CUSTOM/window.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 

--- a/main.cpp
+++ b/main.cpp
@@ -54,7 +54,7 @@ int main()
     Window window(settings.window.width, settings.window.height, settings.window.title);
 
     // Rendering
-    Renderer renderer{};
+    Renderer renderer;
 
     // Texture stuff
     TextureManager textureManager;
@@ -100,12 +100,11 @@ int main()
     };
     
     // VAO (Vertex Array Object)
-    renderer.vertices.createVAO();
+    renderer.createVAO();
     // Vertex buffer
-    renderer.vertices.createVBO(vertices);
+    renderer.createVBO(vertices, sizeof(vertices));
 
-    renderer.vertices.bindVBO(vertices);
-
+    renderer.bindVBO(vertices, sizeof(vertices));
 
 
     // Set the vertex attribute pointers
@@ -151,11 +150,11 @@ int main()
         // Set the texture to use
         if (spacePressed)
         {
-            textureManager.useTexture((char*)"Grass");
+            textureManager.useTexture("Grass");
         }
         else
         {
-            textureManager.useTexture((char*)"Dirt");
+            textureManager.useTexture("Dirt");
         }
 
         // Drawing the triangles =)
@@ -163,7 +162,7 @@ int main()
         numTriangles = sizeof(vertices) / sizeof(float) / 8;
         //glUseProgram(shaderProgram);
         basicShader.use();
-        glBindVertexArray(renderer.vertices.VAO);
+        glBindVertexArray(renderer.VAO);
         glDrawArrays(GL_TRIANGLES, 0, numTriangles);
 
            


### PR DESCRIPTION
The reason why the renderer approach didn't work is because the renderer API only took one parameter, which was an array of floats. However, the array of floats was not of a fixed size. Behind the scenes, a "float[]" in C++ and C is the same thing as a "float*". Therefore, when you do "sizeof(float*)" in code, you end up with the size being 8 (because pointers are 8 bytes in x64).

The renderer needs to be told how big the array is. This PR contains code that changes the renderer API so that the size of the array is also passed in. This means that open GL is told the correct size of the vertex array, and hence renders things correctly.

I also removed the 'struct' from the renderer, and added a few extra pragmas to the header files. I also removed a bunch of unnecessary casts from the code. We can discuss the const issue later when we have time.